### PR TITLE
create the folder that is being exported

### DIFF
--- a/nfs_setup.sh
+++ b/nfs_setup.sh
@@ -6,6 +6,7 @@ mounts="${@}"
 
 for mnt in "${mounts[@]}"; do
   src=$(echo $mnt | awk -F':' '{ print $1 }')
+  mkdir -p $src
   echo "$src *(rw,sync,no_subtree_check,fsid=0,no_root_squash)" >> /etc/exports
 done
 


### PR DESCRIPTION
You need to create the folder that is going to be exported; otherwise, the NFS will give an error if the folder does not exist.