### PR TITLE
fix for issue #10: Servname not supported for ai_socktype

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ADD nfs.stop /etc/sv/nfs/finish
 
 ADD nfs_setup.sh /usr/local/bin/nfs_setup
 
+RUN echo "nfs             2049/tcp" >> /etc/services
+RUN echo "nfs             111/udp" >> /etc/services
+
 VOLUME /exports
 
 EXPOSE 111/udp 2049/tcp


### PR DESCRIPTION
I ran into the same Problem as described here [issue #10](https://github.com/cpuguy83/docker-nfs-server/issues/10). This patch did solve the Problem for me.
