### PR TITLE
problem fix with duplicate export entries, when running the server twice

### DIFF
--- a/nfs_setup.sh
+++ b/nfs_setup.sh
@@ -4,6 +4,8 @@ set -e
 
 mounts="${@}"
 
+echo "#NFS Exports" > /etc/exports
+
 for mnt in "${mounts[@]}"; do
   src=$(echo $mnt | awk -F':' '{ print $1 }')
   mkdir -p $src


### PR DESCRIPTION
When starting the Container a second time, i get the following warning:

←[36mnfs-server    |←[0m  \* Exporting directories for NFS kernel daemon...
←[36mnfs-server    |←[0m exportfs: duplicated export entries:
←[36mnfs-server    |←[0m exportfs:      *:/exports
←[36mnfs-server    |←[0m exportfs:      *:/exports
←[36mnfs-server    |←[0m    ...done.

The reason is, that the nfs_setup.sh script appends the Exports to /etc/exports on each Startup. The added echo starts a new /etc/exports file for each start.
