### PR TITLE
make sure image can be built properly on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+﻿# Ensure sh files use LF.
+*.sh         eol=lf
+nfs.init     eol=lf
+nfs.stop     eol=lf


### PR DESCRIPTION
files are usually checked out with CrLf line endings on Windows, this change is to prevent this to happen for some key files.