### PR TITLE
fix exporting multiple folders

### DIFF
--- a/nfs_setup.sh
+++ b/nfs_setup.sh
@@ -2,11 +2,9 @@
 
 set -e
 
-mounts="${@}"
-
 echo "#NFS Exports" > /etc/exports
 
-for mnt in "${mounts[@]}"; do
+for mnt in "$@"; do
   src=$(echo $mnt | awk -F':' '{ print $1 }')
   mkdir -p $src
   echo "$src *(rw,sync,no_subtree_check,fsid=0,no_root_squash)" >> /etc/exports


### PR DESCRIPTION
with the actual code, `docker run -d --name nfs --privileged cpuguy83/nfs-server a b c` generates:

> a b c *(rw,sync,no_subtree_check,fsid=0,no_root_squash)

this fix it so that it generates :

> a *(rw,sync,no_subtree_check,fsid=0,no_root_squash)
> b *(rw,sync,no_subtree_check,fsid=0,no_root_squash)
> c *(rw,sync,no_subtree_check,fsid=0,no_root_squash)